### PR TITLE
feat: OAuth2 인증 및 로그인 로직 추가

### DIFF
--- a/src/main/java/com/coin/now_coin/common/auth/AuthController.java
+++ b/src/main/java/com/coin/now_coin/common/auth/AuthController.java
@@ -1,0 +1,55 @@
+package com.coin.now_coin.common.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    //로그인 로직
+
+    private final JwtUtil jwtUtil;
+
+    public AuthController(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @GetMapping("/login/google")
+    public String redirectGoogleLogin(){
+        return "redirect:/oauth2/authorization/google";
+    }
+
+
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestParam String refreshToken){
+
+        if (!jwtUtil.validateJwt(refreshToken)) {
+            return ResponseEntity.status(401).body("Invalid refresh token");
+        }
+
+//        //리프레시 토큰에서 유저정보 추출
+//        String providerId = jwtUtil.getClaimValue(refreshToken, "providerId");
+//        //Redis에서 정보 가져옴
+//        String storedRefreshToken = refreshTokenService.getRefreshToken(username);
+//
+//        if (!refreshToken.equals(storedRefreshToken)) {
+//            return ResponseEntity.status(401).body("Refresh token mismatch");
+//        }
+//
+//        String newAccessToken = jwtUtil.generateAccessToken(username);
+//        return ResponseEntity.ok(newAccessToken);
+
+
+        return null;
+
+    }
+    //로그아웃 로직
+
+    //
+}

--- a/src/main/java/com/coin/now_coin/common/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/coin/now_coin/common/auth/CustomOAuth2UserService.java
@@ -1,0 +1,80 @@
+package com.coin.now_coin.common.auth;
+
+
+import com.coin.now_coin.common.auth.dto.CustomOAuth2User;
+import com.coin.now_coin.common.auth.dto.GoogleResponse;
+import com.coin.now_coin.common.auth.dto.NaverResponse;
+import com.coin.now_coin.common.auth.dto.OAuth2Response;
+import com.coin.now_coin.member.MemberRole;
+import com.coin.now_coin.member.MemberService;
+import com.coin.now_coin.member.dto.MemberCreateDto;
+import com.coin.now_coin.member.dto.MemberLoginDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberService memberService;
+
+    @Autowired
+    public CustomOAuth2UserService(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        //extract OAuth2 Provider
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2Response oAuth2Response = null;
+        switch (provider) {
+            case ("google") -> oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+            case ("naver") -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        }
+
+        if (oAuth2Response == null) {
+            throw new OAuth2AuthenticationException("404");
+        }
+
+        //DB에서 있는지확인
+        Boolean isMember = memberService.isMember(oAuth2Response.getProvider(), oAuth2Response.getProviderId());
+
+        log.info("유저정보={}",oAuth2Response.getProviderId());
+        if (!isMember) {
+            //멤버 새로만드는 로직 호출
+            MemberCreateDto build = MemberCreateDto.builder()
+                    .name(oAuth2Response.getName())
+                    .provider(oAuth2Response.getProvider())
+                    .memberRole(MemberRole.READER)
+                    .email(oAuth2Response.getEmail())
+                    .providerId(oAuth2Response.getProviderId())
+                    .build();
+            memberService.saveMember(build);
+        }
+
+        //멤버 정보 불러오는 로직 호출
+        MemberLoginDto memberLoginDto = memberService.getLoginDetails(
+                oAuth2Response.getProvider(),
+                oAuth2Response.getProviderId()
+        );
+
+
+
+
+        return new CustomOAuth2User(memberLoginDto);
+
+
+    }
+
+
+}

--- a/src/main/java/com/coin/now_coin/common/auth/CustomSuccessHandler.java
+++ b/src/main/java/com/coin/now_coin/common/auth/CustomSuccessHandler.java
@@ -1,0 +1,81 @@
+package com.coin.now_coin.common.auth;
+
+
+import com.coin.now_coin.common.auth.dto.CustomOAuth2User;
+import com.coin.now_coin.member.MemberRole;
+import com.coin.now_coin.member.dto.CreateMemberJwtDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler  {
+
+
+    @Value("${frontend.domain}")
+    private String domain;
+
+
+    private final JwtUtil jwtUtil;
+
+    private final  RefreshTokenService refreshTokenService;
+
+    public CustomSuccessHandler(JwtUtil jwtUtil, RefreshTokenService refreshTokenService) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String name = customUserDetails.getName();//get user name
+        MemberRole role = customUserDetails.getRole();//역할 파싱
+        String providerId = customUserDetails.getProviderId();//provider ID 파싱
+
+
+        //엑세스 토큰을 만들기 위한 DTO 생성
+        CreateMemberJwtDto build = CreateMemberJwtDto.builder()
+                .name(name)
+                .memberRole(role)
+                .providerId(providerId)
+                .build();
+
+        String accessToken = jwtUtil.generateAccessToken(build);//엑세스 토큰 생성
+
+        // 엑세스 토큰 생성
+        Cookie jwtCookie = new Cookie("ACCESS_TOKEN", accessToken);
+        jwtCookie.setHttpOnly(true); // JavaScript에서 접근 불가
+        jwtCookie.setPath("/"); // 전체 도메인에서 쿠키 유효
+        jwtCookie.setMaxAge((int) jwtUtil.getExpirationTime()); // 쿠키 만료 시간 (초 단위)
+
+
+
+        //리프레시 토큰 생성
+        String refreshToken = jwtUtil.generateRefreshToken(providerId);
+        Cookie refreshCookie = new Cookie("REFRESH_TOKEN",refreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+        jwtCookie.setMaxAge((int) jwtUtil.getExpirationTime()); // 쿠키 만료 시간 (초 단위)
+        refreshTokenService.saveRefreshTokenToRedis(providerId,refreshToken);//Redis에 토큰 저장
+
+        response.addCookie(jwtCookie);//응답에 엑세스 토큰 추가
+        response.addCookie(refreshCookie);//응답에 리프레시 토큰 추가
+        response.sendRedirect(domain);//응답 반환
+
+
+
+    }
+
+
+
+}

--- a/src/main/java/com/coin/now_coin/common/auth/OAuthProvider.java
+++ b/src/main/java/com/coin/now_coin/common/auth/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.coin.now_coin.common.auth;
+
+public enum OAuthProvider {
+    GOOGLE,
+    NAVER
+}

--- a/src/main/java/com/coin/now_coin/common/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/coin/now_coin/common/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,48 @@
+package com.coin.now_coin.common.auth.dto;
+
+
+import com.coin.now_coin.member.MemberRole;
+import com.coin.now_coin.member.dto.MemberLoginDto;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final MemberLoginDto memberLoginDto;
+
+    public CustomOAuth2User(MemberLoginDto memberLoginDto) {
+        this.memberLoginDto = memberLoginDto;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return memberLoginDto.getName();
+    }
+
+    public String getEmail(){
+        return memberLoginDto.getEmail();
+    }
+    public String getProviderId(){
+
+        return memberLoginDto.getProviderId();
+
+
+    }
+
+    public MemberRole getRole(){
+        return memberLoginDto.getMemberRole();
+    }
+}

--- a/src/main/java/com/coin/now_coin/common/auth/dto/GoogleResponse.java
+++ b/src/main/java/com/coin/now_coin/common/auth/dto/GoogleResponse.java
@@ -1,0 +1,35 @@
+package com.coin.now_coin.common.auth.dto;
+
+import com.coin.now_coin.common.auth.OAuthProvider;
+
+import java.util.Map;
+
+public class GoogleResponse  implements OAuth2Response{
+
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.GOOGLE;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/coin/now_coin/common/auth/dto/OAuth2Response.java
+++ b/src/main/java/com/coin/now_coin/common/auth/dto/OAuth2Response.java
@@ -1,0 +1,16 @@
+package com.coin.now_coin.common.auth.dto;
+
+
+import com.coin.now_coin.common.auth.OAuthProvider;
+
+public interface OAuth2Response {
+
+
+    OAuthProvider getProvider();
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getName();
+}

--- a/src/main/java/com/coin/now_coin/member/LoginController.java
+++ b/src/main/java/com/coin/now_coin/member/LoginController.java
@@ -1,0 +1,21 @@
+package com.coin.now_coin.member;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/api/login")
+     public String redirectLoginPage(){
+
+
+
+        return "redirect:/html/login.html";
+
+
+
+
+    }
+
+}


### PR DESCRIPTION
- OAuth2Response
  - OAuth2 제공자가 반환한 유저 정보를 파싱하기 위한 인터페이스
  - 각 OAuth2 제공자(Google, Naver 등) 별로 구현체를 만들어 사용

- GoogleResponse
  - OAuth2Response 인터페이스를 구현한 클래스
  - Google OAuth2 로그인 시 제공받은 사용자 정보를 파싱하여 저장

- CustomSuccessHandler
  - SimpleUrlAuthenticationSuccessHandler를 상속받아 OAuth2 인증 성공 시 실행되는 로직 구현
  - 액세스 토큰 및 리프레시 토큰을 생성하여 클라이언트에 전송
  - 리프레시 토큰을 Redis에 저장하여 세션 관리 및 인증 갱신 가능하도록 처리

- OAuthProvider
  - OAuth2 인증 제공자(Google, Naver)를 관리하는 Enum 클래스
  - 인증 제공자별 로직을 쉽게 구분하여 확장 가능하도록 설계

- CustomOAuth2User
  - OAuth2User 인터페이스를 구현하여 OAuth2 인증 후 사용자 정보를 관리
  - OAuth2 제공자별로 다른 유저 정보 형식을 통합적으로 핸들링 가능

- CustomOAuth2UserService
  - DefaultOAuth2UserService를 상속받아 OAuth2 인증 제공자가 유저 정보를 보냈을 때의 행동 정의
  - 제공자별 OAuth2Response를 파싱하여 DB에 저장 및 반환
  - 신규 유저는 회원가입, 기존 유저는 로그인 처리

- AuthController
  - 소셜 로그인 요청을 처리하는 컨트롤러
  - 클라이언트에서 소셜 로그인을 요청하면 OAuth2 인증 URL로 리다이렉트

- LoginController
  - 로그인 페이지로 이동하는 API 포함